### PR TITLE
Data feed file by topics to kafka

### DIFF
--- a/shared/kafka/producer.py
+++ b/shared/kafka/producer.py
@@ -1,0 +1,9 @@
+from kafka_configurations import get_producer_config
+
+
+producer = get_producer_config()
+
+def send_messages(topic, messages):
+    for msg in messages:
+        producer.send(topic, msg)
+    producer.flush()


### PR DESCRIPTION
This pull request introduces a new Kafka producer utility to the codebase. The main addition is a helper function for sending messages to a Kafka topic using a shared producer configuration.

Kafka producer utility:

* Added import of `get_producer_config` from `kafka_configurations` and initialized a shared `producer` instance for reuse.
* Implemented a new `send_messages` function in `shared/kafka/producer.py` to send a list of messages to a specified topic and flush the producer after sending.