### PR TITLE
Chaim tech/retriever kafka

### DIFF
--- a/services/retriever/main.py
+++ b/services/retriever/main.py
@@ -1,0 +1,38 @@
+import os
+import time
+from shared.db.connector import MongoDBConnection
+from services.retriever.manager import RetrieverManager
+from shared.kafka.kafka_configurations import get_producer_config
+
+from dotenv import load_dotenv
+load_dotenv()
+
+MONGO_URI = os.getenv("MONGO_URI")
+COLLECTION_NAME = os.getenv("COLLECTION_NAME")
+DB_NAME = MONGO_URI.split("/")[-1] if MONGO_URI else None
+
+producer = get_producer_config()
+
+def publish_to_kafka(batch):
+    for doc in batch:
+        topic = "raw_tweets_antisemitic" if doc.get("antisemietic", 0) else "raw_tweets_not_antisemitic"
+        producer.send(topic, value=doc)
+    producer.flush()
+
+def main():
+    if not MONGO_URI or not DB_NAME:
+        print("Missing MONGO_URI or DB_NAME in environment.")
+        return
+    mongo_conn = MongoDBConnection(MONGO_URI, DB_NAME)
+    manager = RetrieverManager(mongo_conn.db, COLLECTION_NAME)
+    while True:
+        batch = manager.fetch_next(limit=100)
+        if not batch:
+            print("No more tweets to fetch.")
+            break
+        publish_to_kafka(batch)
+        print(f"Published {len(batch)} tweets to Kafka.")
+        time.sleep(60)
+
+if __name__ == "__main__":
+    main()

--- a/shared/db/connector.py
+++ b/shared/db/connector.py
@@ -1,13 +1,9 @@
 import os
 from pymongo import MongoClient
-from dotenv import find_dotenv, load_dotenv
-
-dotenv_path = find_dotenv()
-load_dotenv(dotenv_path)
 
 class MongoDBConnection:
-    def __init__(self):
-        self.connection_string = os.getenv("MONGODB_CONNECTION_STRING")
+    def __init__(self, connection_string):
+        self.connection_string = connection_string
         self.client = None
 
     def __enter__(self):


### PR DESCRIPTION
This pull request introduces a new main entry point for the retriever service and refactors the MongoDB connection logic to improve configurability and integration with environment variables. The changes focus on enabling batch retrieval of tweets from MongoDB and publishing them to Kafka, as well as making the database connector more flexible.

**Retriever Service Initialization and Kafka Publishing:**
* Added a new `main.py` script in `services/retriever` that loads environment variables, initializes MongoDB and Kafka connections, fetches batches of tweets, and publishes them to different Kafka topics based on tweet content.

**Database Connector Refactoring:**
* Refactored `MongoDBConnection` in `shared/db/connector.py` to accept the connection string as an argument instead of reading directly from environment variables, improving reusability and flexibility for different services.