### PR TITLE
Fix NLTK data path in TextProcessor to point to resources/nltk_data

### DIFF
--- a/shared/text_processing/text_processor.py
+++ b/shared/text_processing/text_processor.py
@@ -3,7 +3,7 @@ import nltk
 from nltk.stem import WordNetLemmatizer
 from nltk.corpus import stopwords
 
-nltk.data.path.append("nltk_data")
+nltk.data.path.append("resources/nltk_data")
 
 class TextProcessor:
     def __init__(self):


### PR DESCRIPTION
This pull request makes a minor update to the configuration of the NLTK data path in the `TextProcessor` class to use a more specific directory.

* Changed the NLTK data path in `shared/text_processing/text_processor.py` from `"nltk_data"` to `"resources/nltk_data"` to ensure resources are loaded from the correct location.