### PR TITLE
Add build and push script for Docker images of all services

### DIFF
--- a/scripts/build_and_push_all.bat
+++ b/scripts/build_and_push_all.bat
@@ -1,0 +1,22 @@
+@echo off
+REM Build and push all service images to Docker Hub
+
+set REPO=chaimshvadron/iranian-terror-tweets-hunter
+
+REM Build images
+
+docker build -t %REPO%-retriever:latest -f services/retriever/Dockerfile .
+docker build -t %REPO%-preprocessor:latest -f services/preprocessor/Dockerfile .
+docker build -t %REPO%-enricher:latest -f services/enricher/Dockerfile .
+docker build -t %REPO%-persister:latest -f services/persister/Dockerfile .
+docker build -t %REPO%-dataretrieval:latest -f services/dataretrieval/Dockerfile .
+
+REM Push images
+
+docker push %REPO%-retriever:latest
+docker push %REPO%-preprocessor:latest
+docker push %REPO%-enricher:latest
+docker push %REPO%-persister:latest
+docker push %REPO%-dataretrieval:latest
+
+echo All images built and pushed successfully!


### PR DESCRIPTION
This pull request adds a new batch script to automate building and pushing all service Docker images to Docker Hub. This improves deployment efficiency by consolidating the build and push steps for multiple services into a single command.

Deployment automation:

* Added `scripts/build_and_push_all.bat` to build and push Docker images for all services (`retriever`, `preprocessor`, `enricher`, `persister`, `dataretrieval`) to Docker Hub using a consistent repository naming convention.